### PR TITLE
Fix Lithuanian validator

### DIFF
--- a/src/vies/Validators/LTVatValidator.cs
+++ b/src/vies/Validators/LTVatValidator.cs
@@ -23,7 +23,7 @@ namespace Padi.Vies.Validators
         {
             if (vat.Length == 9)
             {
-                if (vat[8] != '1')
+                if (vat[7] != '1')
                 {
                     return VatValidationResult.Failed("9 character VAT numbers should have 1 in 8th position.");
                 }

--- a/tests/vies-test/ViesUnitTest.cs
+++ b/tests/vies-test/ViesUnitTest.cs
@@ -209,6 +209,7 @@ namespace Padi.Vies.Test
         [InlineData("PT 980526779")]
         [InlineData(" BE0000200334")]
         [InlineData("SK2120046819")]
+        [InlineData("LT684289716")]
         public void Should_Validate_Vat(string vatNumber)
         {
             Assert.True(ViesManager.IsValid(vatNumber).IsValid);


### PR DESCRIPTION
See e.g. https://github.com/se-panfilov/jsvat/blob/master/src/lib/countries/lithuania.ts#L58

The code should validate that the 8th digit is a "1", but instead checks the 9th digit.