### PR TITLE
fix CY VAT Validation

### DIFF
--- a/src/vies/Validators/CYVatValidator.cs
+++ b/src/vies/Validators/CYVatValidator.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Text.RegularExpressions;
 
 namespace Padi.Vies.Validators
@@ -55,7 +56,7 @@ namespace Padi.Vies.Validators
             }
 
             var checkDigit = result % 26;
-            var isValid = vat[8].ToInt() == checkDigit + 65;
+            var isValid = Convert.ToInt32(vat[8]) == checkDigit + 65;
 
             return !isValid 
                 ? VatValidationResult.Failed("Invalid CY vat: checkValue") 

--- a/tests/vies-test/ViesUnitTest.cs
+++ b/tests/vies-test/ViesUnitTest.cs
@@ -143,6 +143,7 @@ namespace Padi.Vies.Test
         [InlineData("RO4107779")]
         [InlineData("RO00099908")]
         [InlineData("RO0000099908")]
+        [InlineData("CY10014000M")]
         [InlineData("   FR00000000190")]
         [InlineData("   FR00300076965")]
         [InlineData("   FR00303656847")]


### PR DESCRIPTION
Must not substract the char value of "0" in this case.