### PR TITLE
Send empty SoapOperation header

### DIFF
--- a/src/vies/ViesManager.cs
+++ b/src/vies/ViesManager.cs
@@ -210,7 +210,7 @@ namespace Padi.Vies
                     MediaTypeXml);
             requestMessage.Headers.Clear();
             requestMessage.Content.Headers.ContentType = new MediaTypeHeaderValue(MediaTypeXml);
-            requestMessage.Headers.Add("SOAPAction", "urn:ec.europa.eu:taxud:vies:services:checkVat");
+            requestMessage.Headers.Add("SOAPAction", string.Empty);
 
             try
             {


### PR DESCRIPTION
fixes #10  "The given SOAPAction urn:ec.europa.eu:taxud:vies:services:checkVat does not match an operation."

https://stackoverflow.com/questions/2262781/soap-action-wsdl

> https://www.w3.org/TR/2000/NOTE-SOAP-20000508/#_Toc478383528
> "The header field value of empty string ("") means that the intent of the SOAP message is provided by the HTTP Request-URI."