### PR TITLE
Allow new VAT numbers in Belgium

### DIFF
--- a/src/vies-dotnet-api/Validators/BEVatValidator.cs
+++ b/src/vies-dotnet-api/Validators/BEVatValidator.cs
@@ -19,7 +19,7 @@ using System.Text.RegularExpressions;
 namespace Padi.Vies.Validators;
 
 /// <summary>
-/// 
+///
 /// </summary>
 [SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses")]
 public sealed class BeVatValidator : VatValidatorAbstract
@@ -34,14 +34,14 @@ public sealed class BeVatValidator : VatValidatorAbstract
         this.Regex = _regex;
         CountryCode = COUNTRY_CODE;
     }
-        
+
     protected override VatValidationResult OnValidate(string vat)
     {
-        if (vat.Length == 10 && vat[0] != '0')
+        if (vat.Length == 10 && vat[0] != '0' && vat[0] != '1')
         {
             return VatValidationResult.Failed("First character of 10 digit numbers should be 0.");
         }
-            
+
         if (vat.Length == 9)
         {
             vat = vat.PadLeft(10, '0');


### PR DESCRIPTION
Addressed in this update is the validation support for the recently introduced Belgian VAT numbers that commence with the digit "1". For additional context, refer to the [VAT update](https://www.vatupdate.com/2023/10/03/vat-and-company-numbers-now-also-start-with-the-number-1/#:~:text=From%20now%20on%2C%20all%20new,0%20has%20been%20used%20up.).